### PR TITLE
Escape path to working directory.

### DIFF
--- a/plugin/ycm-generator.vim
+++ b/plugin/ycm-generator.vim
@@ -10,7 +10,7 @@ function! s:GenerateConfig(fmt, flags)
     " Only append the working directory if the last option is a flag
     let l:split_flags = split(a:flags)
     if len(l:split_flags) == 0 || l:split_flags[-1] =~ "^-"
-        let l:cmd = l:cmd . " " . getcwd()
+        let l:cmd = l:cmd . " " . fnameescape(getcwd())
     endif
 
     execute l:cmd


### PR DESCRIPTION
The output of getcwd() is passed directly to to config_gen.py which doesn't work if there are special characters (such as spaces) in the path.

For example:

```
$ cd /tmp
$ mkdir "some directory with spaces"
$ cd "some directory with spaces"
$ gvim foo.c
:YcmGenerateConfig

:! /home/samuel/.vim/bundle/YCM-Generator/config_gen.py -F ycm  /tmp/some directory with spaces
usage: config_gen.py [-h] [-v] [-m MAKE] [-c COMPILER] [-C CONFIGURE_OPTS] [-F {ycm,cc}] [-M MAKE_FLAGS] [-o OUTPUT] [-x {c,c++}] [--out-of-tree] [-e] PROJECT_DIR
config_gen.py: error: unrecognized arguments: directory with spaces

shell returned 2
```
