### PR TITLE
add imacros option support

### DIFF
--- a/config_gen.py
+++ b/config_gen.py
@@ -341,11 +341,7 @@ def parse_flags(build_log):
 
             # include arguments for this option, if there are any, as a tuple
             if(i != len(words) - 1 and word in filename_flags and words[i + 1][0] != '-'):
-                if (word == "-imacros"):
-                    word += words[i + 1]
-                    flags.add(word)
-                else:
-                    flags.add((word, words[i + 1]))
+                flags.add((word, words[i + 1]))
             else:
                 flags.add(word)
 

--- a/config_gen.py
+++ b/config_gen.py
@@ -314,7 +314,7 @@ def parse_flags(build_log):
     define_regex = re.compile("-D([a-zA-Z0-9_]+)=(.*)")
 
     # Used to only bundle filenames with applicable arguments
-    filename_flags = ["-o", "-I", "-isystem", "-include"]
+    filename_flags = ["-o", "-I", "-isystem", "-include", "-imacros"]
 
     # Process build log
     for line in build_log:
@@ -341,7 +341,11 @@ def parse_flags(build_log):
 
             # include arguments for this option, if there are any, as a tuple
             if(i != len(words) - 1 and word in filename_flags and words[i + 1][0] != '-'):
-                flags.add((word, words[i + 1]))
+                if (word == "-imacros"):
+                    word += words[i + 1]
+                    flags.add(word)
+                else:
+                    flags.add((word, words[i + 1]))
             else:
                 flags.add(word)
 


### PR DESCRIPTION
-imacros is a compiler option with an option-argument(filename).YCM-Generator treats it as a common option, so I add support for it.
And this format in flags doesn't work,testing on two projects(maybe the problem results from ycm itself):
'-imacros',
'<filename>',
so I combine both into one line.
