### PR TITLE
Allow build system to be specified on the command line

### DIFF
--- a/config_gen.py
+++ b/config_gen.py
@@ -118,9 +118,14 @@ def main():
                 c_count = 0
 
             if(c_count == 0 and cxx_count == 0):
-                print()
+                print("")
                 print("ERROR: No commands were logged to the build logs (C: {}, C++: {}).".format(c_build_log.name, cxx_build_log.name))
                 print("Your build system may not be compatible.")
+
+                if(not args["verbose"]):
+                    print("")
+                    print("Try running with the --verbose flag to see build system output - the most common cause of this is a hardcoded compiler path.")
+
                 c_build_log.delete = False
                 cxx_build_log.delete = False
                 return 3

--- a/config_gen.py
+++ b/config_gen.py
@@ -330,7 +330,7 @@ def parse_flags(build_log):
     # -warnings (-Werror), but no assembler, etc. flags (-Wa,-option)
     # -language (-std=gnu99) and standard library (-nostdlib)
     # -word size (-m64)
-    flags_whitelist = ["-[iID].*", "-W[^,]*", "-std=[a-z0-9+]+", "-(no)?std(lib|inc)", "-m[0-9]+"]
+    flags_whitelist = ["-[iIDF].*", "-W[^,]*", "-std=[a-z0-9+]+", "-(no)?std(lib|inc)", "-m[0-9]+"]
     flags_whitelist = re.compile("|".join(map("^{}$".format, flags_whitelist)))
     flags = set()
     line_count = 0

--- a/config_gen.py
+++ b/config_gen.py
@@ -267,7 +267,16 @@ def fake_build(project_dir, c_build_log_path, cxx_build_log_path, verbose, make_
         build_dir = tempfile.mkdtemp()
         proc_opts["cwd"] = build_dir
         env_config["QT_SELECT"] = qt_version
-        env_config["QMAKESPEC"] = "unsupported/linux-clang" if qt_version == "4" else "linux-clang"
+
+        # QMAKESPEC is platform dependent - valid mkspecs are in
+        # /usr/share/qt4/mkspecs, /usr/lib64/qt5/mkspecs
+        env_config["QMAKESPEC"] = {
+            ("Linux",  True):   "unsupported/linux-clang",
+            ("Linux",  False):  "linux-clang",
+            ("Darwin", True):   "unsupported/macx-clang",
+            ("Darwin", False):  "macx-clang",
+            ("FreeBSD", False): "unsupported/freebsd-clang",
+        }[(os.uname()[0], qt_version == "4")]
 
         print("Running qmake in '{}' with Qt {}...".format(build_dir, qt_version))
         run(["qmake"] + configure_opts + [pro_files[0]], env=env_config,

--- a/config_gen.py
+++ b/config_gen.py
@@ -32,6 +32,7 @@ def main():
     parser.add_argument("-v", "--verbose", action="store_true", help="Show output from build process")
     parser.add_argument("-f", "--force", action="store_true", help="Overwrite the file if it exists.")
     parser.add_argument("-m", "--make", default="make", help="Use the specified executable for make.")
+    parser.add_argument("-b", "--build-system", choices=["cmake", "autotools", "qmake", "make"], help="Force use of the specified build system rather than trying to autodetect.")
     parser.add_argument("-c", "--compiler", help="Use the specified executable for clang. It should be the same version as the libclang used by YCM. The executable for clang++ will be inferred from this.")
     parser.add_argument("-C", "--configure_opts", default="", help="Additional flags to pass to configure/cmake/etc. e.g. --configure_opts=\"--enable-FEATURE\"")
     parser.add_argument("-F", "--format", choices=["ycm", "cc"], default="ycm", help="Format of output file (YouCompleteMe or color_coded). Default: ycm")
@@ -139,7 +140,7 @@ def main():
             print("Created {} config file with {} {} flags".format(output_format.upper(), len(flags), lang.upper()))
 
 
-def fake_build(project_dir, c_build_log_path, cxx_build_log_path, verbose, make_cmd, cc, cxx, out_of_tree, configure_opts, make_flags, preserve_environment, qt_version):
+def fake_build(project_dir, c_build_log_path, cxx_build_log_path, verbose, make_cmd, build_system, cc, cxx, out_of_tree, configure_opts, make_flags, preserve_environment, qt_version):
     '''Builds the project using the fake toolchain, to collect the compiler flags.
 
     project_dir: the directory containing the source files
@@ -202,8 +203,21 @@ def fake_build(project_dir, c_build_log_path, cxx_build_log_path, verbose, make_
         print("$ " + " ".join(cmd))
         subprocess.call(cmd, *args, **kwargs)
 
+    if build_system is None:
+        if os.path.exists(os.path.join(project_dir, "CMakeLists.txt")):
+            build_system = "cmake"
+        elif os.path.exists(os.path.join(project_dir, "configure")):
+            build_system = "autotools"
+        elif pro_files:
+            build_system = "qmake"
+        elif any([os.path.exists(os.path.join(project_dir, x)) for x in ["GNUmakefile", "makefile", "Makefile"]]):
+            build_system = "make"
+        else:
+            print("ERROR: Unknown build system")
+            sys.exit(2)
+
     # execute the build system
-    if(os.path.exists(os.path.join(project_dir, "CMakeLists.txt"))):
+    if build_system == "cmake":
         # cmake
         # run cmake in a temporary directory, then compile the project as usual
         build_dir = tempfile.mkdtemp()
@@ -236,7 +250,7 @@ def fake_build(project_dir, c_build_log_path, cxx_build_log_path, verbose, make_
         if(cache_tmp):
             shutil.move(cache_tmp, cache_path)
 
-    elif(os.path.exists(os.path.join(project_dir, "configure"))):
+    elif build_system == "autotools":
         # autotools
         # perform build in-tree, since not all projects handle out-of-tree builds correctly
 
@@ -260,7 +274,7 @@ def fake_build(project_dir, c_build_log_path, cxx_build_log_path, verbose, make_
         else:
             run([make_cmd, "maintainer-clean"], env=env, **proc_opts)
 
-    elif(pro_files):
+    elif build_system == "qmake":
         # qmake
         # make sure there is only one .pro file
         if len(pro_files) != 1:
@@ -294,7 +308,7 @@ def fake_build(project_dir, c_build_log_path, cxx_build_log_path, verbose, make_
         print("")
         shutil.rmtree(build_dir)
 
-    elif(any([os.path.exists(os.path.join(project_dir, x)) for x in ["GNUmakefile", "makefile", "Makefile"]])):
+    elif build_system == "make":
         # make
         # needs to be handled last, since other build systems can generate Makefiles
         print("Preparing build directory...")
@@ -302,10 +316,6 @@ def fake_build(project_dir, c_build_log_path, cxx_build_log_path, verbose, make_
 
         print("\nRunning make...")
         run(make_args, env=env, **proc_opts)
-
-    else:
-        print("ERROR: Unknown build system")
-        sys.exit(2)
 
     print("Build completed in {} sec".format(round(time.time() - started, 2)))
     print("")

--- a/fake-toolchain/Unix/cxx
+++ b/fake-toolchain/Unix/cxx
@@ -6,7 +6,7 @@ if [ ! -z "$YCM_CONFIG_GEN_CC_PASSTHROUGH" ]; then
 
 elif [ "$1" = "-v" ] || [ "$1" = "--version" ]; then
     # Needed to enable clang-specific options for certain build systems (e.g. linux)
-    $YCM_CONFIG_GEN_CC_PASSTHROUGH $@
+    $YCM_CONFIG_GEN_CXX_PASSTHROUGH $@
 
 else
     echo "$@" >> $YCM_CONFIG_GEN_CXX_LOG


### PR DESCRIPTION
This is useful since some projects have files for multiple build systems.
