### PR TITLE
Fixed the issue of C/C++ std headers not found

### DIFF
--- a/config_gen.py
+++ b/config_gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 import sys
 import os


### PR DESCRIPTION
In the FAQ of [Valloric/YouCompleteMe](https://github.com/Valloric/YouCompleteMe), there is an [issue of C/C++ standard library headers not found](Valloric/YouCompleteMe#303) that affects some users (mainly on OS X) and has been resolved with a workaround, and @cpradog has kindly provided a [working implementation](https://gist.github.com/cpradog/aad88d51001ea83ecfc6). 

Basically, what this workaround does is to execute `echo | clang -v -E -x c++ -`, as instructed by `YouCompleteMe`, extract the paths to where the standard headers reside, and append to the include path generated by `.ycm_extra_conf.py`. Therefore, it will not interfere with other functionalities.

Since [rdnetto/YCM-Generator](https://github.com/rdnetto/YCM-Generator) is recommended to use in the front page of [Valloric/YouCompleteMe](https://github.com/Valloric/YouCompleteMe), it's probably worth incorporating this workaround for users' convenience.

Also, the 1st line `#!/usr/bin/env python2` in `config_gen.py` is not universal, so it's changed to `#!/usr/bin/env python`.
