### PR TITLE
Add support for syntastic-extras config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ This is a script which generates a list of compiler flags from a project with an
 
 * generate a ```.ycm_extra_conf.py``` file for use with [YouCompleteMe](https://github.com/Valloric/YouCompleteMe)
 * generate a ```.color_coded``` file for use with [color_coded](https://github.com/jeaye/color_coded)
+* generate a ```.syntastic_<type>_config``` file for use with [syntastic-extras](https://github.com/myint/syntastic-extras)
 
 It works by building the project with a fake toolchain, which simply and filters compiler flags to be stored in the resulting file.
 

--- a/config_gen.py
+++ b/config_gen.py
@@ -87,7 +87,7 @@ def main():
 
     for _config_file in glob.glob(config_file):
         if(os.path.exists(_config_file) and not args["force"]):
-            print("'{}' already exists. Overwrite? [y/N] ".format(config_file)),
+            print("'{}' already exists. Overwrite? [y/N] ".format(_config_file)),
             response = sys.stdin.readline().strip().lower()
 
             if(response != "y" and response != "yes"):

--- a/config_gen.py
+++ b/config_gen.py
@@ -233,7 +233,7 @@ def fake_build(project_dir, c_build_log_path, cxx_build_log_path, verbose, make_
         build_dir = tempfile.mkdtemp()
         proc_opts["cwd"] = build_dir
 
-        # if the project was built Generatorin-tree, we need to hide the cache file so that cmake
+        # if the project was built in-tree, we need to hide the cache file so that cmake
         # populates the build dir instead of just re-generating the existing files
         cache_path = os.path.join(project_dir, "CMakeCache.txt")
 
@@ -473,7 +473,7 @@ def parse_flags(build_log, with_abspath):
     return (line_count, skip_count, sorted(flags, key=lambda x:x[0] if isinstance(x, tuple) else x))
 
 def rta_path(dummy_path, cur_path):
-    ''' Traslate the relative path to the absolute path
+    ''' Translate the relative path to the absolute path
 
     dummy_path: the path contains '../' or './'
     cur_path: the path of compiled file which is read from build_log'''

--- a/config_gen.py
+++ b/config_gen.py
@@ -233,7 +233,7 @@ def fake_build(project_dir, c_build_log_path, cxx_build_log_path, verbose, make_
         build_dir = tempfile.mkdtemp()
         proc_opts["cwd"] = build_dir
 
-        # if the project was built in-tree, we need to hide the cache file so that cmake
+        # if the project was built Generatorin-tree, we need to hide the cache file so that cmake
         # populates the build dir instead of just re-generating the existing files
         cache_path = os.path.join(project_dir, "CMakeCache.txt")
 
@@ -419,6 +419,8 @@ def parse_flags(build_log, with_abspath):
             #Read the variable cur_path from the build_log
             if 'cur_path=' in line:
                 cur_path = line.split('=', 1)[1].replace('\n', '') + '/'
+                #Skip the cur_path line whitout counting
+                skip_count -= 1
             skip_count += 1
             continue
 

--- a/fake-toolchain/Unix/cc
+++ b/fake-toolchain/Unix/cc
@@ -9,8 +9,7 @@ elif [ "$1" = "-v" ] || [ "$1" = "--version" ]; then
     $YCM_CONFIG_GEN_CC_PASSTHROUGH $@
 
 else
-    path=`pwd`
-    echo "cur_path=$path" >> $YCM_CONFIG_GEN_CC_LOG
+    echo "cur_path=$(pwd)" >> $YCM_CONFIG_GEN_CC_LOG
     echo "$@" >> $YCM_CONFIG_GEN_CC_LOG
 fi
 

--- a/fake-toolchain/Unix/cc
+++ b/fake-toolchain/Unix/cc
@@ -9,6 +9,8 @@ elif [ "$1" = "-v" ] || [ "$1" = "--version" ]; then
     $YCM_CONFIG_GEN_CC_PASSTHROUGH $@
 
 else
+    path=`pwd`
+    echo "cur_path=$path" >> $YCM_CONFIG_GEN_CC_LOG
     echo "$@" >> $YCM_CONFIG_GEN_CC_LOG
 fi
 

--- a/fake-toolchain/Unix/cxx
+++ b/fake-toolchain/Unix/cxx
@@ -10,7 +10,7 @@ elif [ "$1" = "-v" ] || [ "$1" = "--version" ]; then
 
 else
     path=`pwd`
-    echo "$path" >> $YCM_CONFIG_GEN_CXX_LOG
+    echo "cur_path=$path" >> $YCM_CONFIG_GEN_CXX_LOG
     echo "$@" >> $YCM_CONFIG_GEN_CXX_LOG
 fi
 

--- a/fake-toolchain/Unix/cxx
+++ b/fake-toolchain/Unix/cxx
@@ -9,8 +9,7 @@ elif [ "$1" = "-v" ] || [ "$1" = "--version" ]; then
     $YCM_CONFIG_GEN_CXX_PASSTHROUGH $@
 
 else
-    path=`pwd`
-    echo "cur_path=$path" >> $YCM_CONFIG_GEN_CXX_LOG
+    echo "cur_path=$(pwd)" >> $YCM_CONFIG_GEN_CXX_LOG
     echo "$@" >> $YCM_CONFIG_GEN_CXX_LOG
 fi
 

--- a/fake-toolchain/Unix/cxx
+++ b/fake-toolchain/Unix/cxx
@@ -9,6 +9,8 @@ elif [ "$1" = "-v" ] || [ "$1" = "--version" ]; then
     $YCM_CONFIG_GEN_CXX_PASSTHROUGH $@
 
 else
+    path=`pwd`
+    echo "$path" >> $YCM_CONFIG_GEN_CXX_LOG
     echo "$@" >> $YCM_CONFIG_GEN_CXX_LOG
 fi
 

--- a/template.py
+++ b/template.py
@@ -27,6 +27,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 # For more information, please refer to <http://unlicense.org/>
+# -*- coding: utf-8 -*-
 
 import os
 import ycm_core
@@ -40,12 +41,12 @@ flags = [
 
 
 def LoadSystemIncludes():
-    regex = re.compile(ur'(?:\#include \<...\> search starts here\:)(?P<list>.*?)(?:End of search list)', re.DOTALL);
+    regex = re.compile(r'(?:\#include \<...\> search starts here\:)(?P<list>.*?)(?:End of search list)', re.DOTALL);
     process = subprocess.Popen(['clang', '-v', '-E', '-x', 'c++', '-'], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE);
     process_out, process_err = process.communicate('');
     output = process_out + process_err;
     includes = [];
-    for p in re.search(regex, output).group('list').split('\n'):
+    for p in re.search(regex, str(output)).group('list').split('\n'):
         p = p.strip();
         if len(p) > 0 and p.find('(framework directory)') < 0:
             includes.append('-isystem');


### PR DESCRIPTION
Hi
I have added a new format for YCM-Generator which is syntastic-extras.
First , syntastic-extras can't follow the relative path which file flags use, so I add a function to translate the relative path to absolute path.Though I don't think the way is that simple and direct.
I changed c/cxx in fake-toolchain to make them print their current working directory, then combining the working path and relative path to get the absolute path of the file.
Sencond, The format like "-I../include" is handled separately. I also find maybe there is a path format like "/home/user/project/src/../include" so I make a if-else in rta_path function.  
Third, the config file of syntastic-extras have different names for c and c++, so I use a wildcard to solve the problem.
Could you give me some advice if you have better way to achieve this?
In fact, I am not good at neither python nor English. : )
Thanks in advance.
ssfdust