### PR TITLE
Normalize path arguments

### DIFF
--- a/config_gen.py
+++ b/config_gen.py
@@ -394,7 +394,7 @@ def parse_flags(build_log):
 
             # include arguments for this option, if there are any, as a tuple
             if(i != len(words) - 1 and word in filename_flags and words[i + 1][0] != '-'):
-                flags.add((word, words[i + 1]))
+                flags.add((word, os.path.normpath(words[i + 1])))
             else:
                 flags.add(word)
 


### PR DESCRIPTION
Include path arguments sometimes contain redundant path elements, especially if they are derived from the compiler internal include paths. This patch introduces normalization of all path arguments, making it easier to debug path problem in YCM and CC