### PR TITLE
ROS catkin support: replace the tmp catkin devel/include with the one from the workspace

### DIFF
--- a/config_gen.py
+++ b/config_gen.py
@@ -432,6 +432,10 @@ def parse_flags(build_log):
     # Used to only bundle filenames with applicable arguments
     filename_flags = ["-o", "-I", "-isystem", "-iquote", "-include", "-imacros", "-isysroot"]
 
+    temp_catkin_regex = re.compile("-I/tmp/tmp[a-zA-Z0-9]+/")
+    catkin_ws_regex = re.compile("-I.*(catkin_workspace|catkin_ws)/")
+    catkin_ws = ''
+
     # Process build log
     for line in build_log:
         if(temp_output.search(line)):
@@ -455,11 +459,20 @@ def parse_flags(build_log):
 
                 continue
 
+            # Find our what the catkin_ws path is
+            if catkin_ws_regex.search(word):
+                catkin_ws = catkin_ws_regex.search(word).group()
+
             # include arguments for this option, if there are any, as a tuple
             if(i != len(words) - 1 and word in filename_flags and words[i + 1][0] != '-'):
                 flags.add((word, words[i + 1]))
+            elif temp_catkin_regex.search(word):
+                # replace the tmp catkin devel/include folder
+                word = temp_catkin_regex.sub(catkin_ws, word)
+                flags.add(word)
             else:
                 flags.add(word)
+
 
     # Only specify one word size (the largest)
     # (Different sizes are used for different files in the linux kernel.)


### PR DESCRIPTION
When developing with ROS and catkin_make files get deployed into a 'devel' folder during the build process. Apart from libraries and binaries, also auto-generated header files will be installed into this folder structure under 'devel/include'.
When doing a fake-build with YCM-Generator, this devel folder gets created in /tmp and this is then entered in the config. Up until now it is necessary to adapt this path manually after letting YCM-Generator run, which is necessary each time a new package is added to the workspace, as they bring their own new include directories.

This patch searches for the base directory by parsing the include paths for the keywords 'catkin_workspace' or 'catkin_ws'.

I am very well aware, that this patch is not yet ready to merge, for now I would only like to know whether a patch like this, which is very specific to ROS/catkin_make has a chance to get merged or not.

If you think that this is too specific to get merged, just decline this PR, then I'll try to maintain my own fork with those changes.

Cheers
Felix