### PR TITLE
add '-target' to whitelist

### DIFF
--- a/config_gen.py
+++ b/config_gen.py
@@ -420,7 +420,7 @@ def parse_flags(build_log):
     # -warnings (-Werror), but no assembler, etc. flags (-Wa,-option)
     # -language (-std=gnu99) and standard library (-nostdlib)
     # -word size (-m64)
-    flags_whitelist = ["-[iIDF].*", "-W[^,]*", "-std=[a-z0-9+]+", "-(no)?std(lib|inc)", "-m[0-9]+"]
+    flags_whitelist = ["-[iIDF].*", "-W[^,]*", "-std=[a-z0-9+]+", "-(no)?std(lib|inc)", "-m[0-9]+", "-target"]
     flags_whitelist = re.compile("|".join(map("^{}$".format, flags_whitelist)))
     flags = set()
     line_count = 0
@@ -430,7 +430,7 @@ def parse_flags(build_log):
     define_regex = re.compile("-D([a-zA-Z0-9_]+)=(.*)")
 
     # Used to only bundle filenames with applicable arguments
-    filename_flags = ["-o", "-I", "-isystem", "-iquote", "-include", "-imacros", "-isysroot"]
+    filename_flags = ["-o", "-I", "-isystem", "-iquote", "-include", "-imacros", "-isysroot", "-target"]
 
     # Process build log
     for line in build_log:

--- a/fake-toolchain/Unix/arm-none-eabi-g++
+++ b/fake-toolchain/Unix/arm-none-eabi-g++
@@ -1,1 +1,14 @@
-cxx
+#!/bin/sh
+
+if [ ! -z "$YCM_CONFIG_GEN_CC_PASSTHROUGH" ]; then
+    # Cmake determines compiler properties by compiling a test file, so call clang for this case
+    $YCM_CONFIG_GEN_CXX_PASSTHROUGH $@
+
+elif [ "$1" = "-v" ] || [ "$1" = "--version" ]; then
+    # Needed to enable clang-specific options for certain build systems (e.g. linux)
+    $YCM_CONFIG_GEN_CXX_PASSTHROUGH $@
+
+else
+    echo "$@" >> $YCM_CONFIG_GEN_CXX_LOG -target arm-none-eabi
+fi
+

--- a/fake-toolchain/Unix/arm-none-eabi-gcc
+++ b/fake-toolchain/Unix/arm-none-eabi-gcc
@@ -1,1 +1,14 @@
-cc
+#!/bin/sh
+
+if [ ! -z "$YCM_CONFIG_GEN_CC_PASSTHROUGH" ]; then
+    # Cmake determines compiler properties by compiling a test file, so call clang for this case
+    $YCM_CONFIG_GEN_CC_PASSTHROUGH $@
+
+elif [ "$1" = "-v" ] || [ "$1" = "--version" ]; then
+    # Needed to enable clang-specific options for certain build systems (e.g. linux)
+    $YCM_CONFIG_GEN_CC_PASSTHROUGH $@
+
+else
+    echo "$@" >> $YCM_CONFIG_GEN_CC_LOG -target arm-none-eabi
+fi
+

--- a/fake-toolchain/Unix/avr-g++
+++ b/fake-toolchain/Unix/avr-g++
@@ -1,1 +1,16 @@
-cxx
+#!/bin/sh
+
+AVR_LIB=$(cat /tmp/avr_gcc_include)
+
+if [ ! -z "$YCM_CONFIG_GEN_CC_PASSTHROUGH" ]; then
+    # Cmake determines compiler properties by compiling a test file, so call clang for this case
+    $YCM_CONFIG_GEN_CXX_PASSTHROUGH $@
+
+elif [ "$1" = "-v" ] || [ "$1" = "--version" ]; then
+    # Needed to enable clang-specific options for certain build systems (e.g. linux)
+    $YCM_CONFIG_GEN_CXX_PASSTHROUGH $@
+
+else
+    echo "$@" >> $YCM_CONFIG_GEN_CXX_LOG -isystem $AVR_LIB -D__flash= --target=avr
+fi
+

--- a/fake-toolchain/Unix/avr-gcc
+++ b/fake-toolchain/Unix/avr-gcc
@@ -1,1 +1,16 @@
-cc
+#!/bin/sh
+
+AVR_LIB=$(cat /tmp/avr_gcc_include)
+
+if [ ! -z "$YCM_CONFIG_GEN_CC_PASSTHROUGH" ]; then
+    # Cmake determines compiler properties by compiling a test file, so call clang for this case
+    $YCM_CONFIG_GEN_CC_PASSTHROUGH $@
+
+elif [ "$1" = "-v" ] || [ "$1" = "--version" ]; then
+    # Needed to enable clang-specific options for certain build systems (e.g. linux)
+    $YCM_CONFIG_GEN_CC_PASSTHROUGH $@
+
+else
+    echo "$@" >> $YCM_CONFIG_GEN_CC_LOG -isystem $AVR_LIB -D__flash= --target=avr
+fi
+

--- a/template.py
+++ b/template.py
@@ -36,11 +36,22 @@ import ycm_core
 import re
 import subprocess
 
+import os.path as p
+import sys
+
+DIR_OF_THIS = p.abspath(p.dirname(__file__))
+sys.path.append(DIR_OF_THIS)
+
+try:
+    from ycm_extra_manual_config import extra_flags
+except ImportError:
+    extra_flags = []
 
 flags = [
     # INSERT FLAGS HERE
 ]
 
+flags += extra_flags
 
 def LoadSystemIncludes():
     regex = re.compile(r'(?:\#include \<...\> search starts here\:)(?P<list>.*?)(?:End of search list)', re.DOTALL)


### PR DESCRIPTION
e.g. -target arm-none-eabi
In your prefered build system you could add this build flag.
for Makefile:
```
ifeq($(YCMG), 1)
    CFLAGS += -target arm-none-eabi
endif
```
and start the generator in vim with:
`YCMGeneratConfig -M=YCMG=1 -f`

Probably this could be done automatically with the fake build system?